### PR TITLE
Constants for MITOC trip fees

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,35 @@
+[MESSAGES CONTROL]
+
+disable=
+  attribute-defined-outside-init,
+  fixme,
+  invalid-name,
+  len-as-condition,
+  line-too-long,
+  locally-disabled,
+  locally-enabled,
+  missing-docstring,
+  no-init,
+  no-else-return,
+  no-member,
+  no-self-use,
+  old-style-class,
+  protected-access,
+  too-few-public-methods,
+  too-many-ancestors,
+  too-many-arguments,
+  too-many-branches,
+  too-many-instance-attributes,
+  too-many-locals,
+  too-many-public-methods,
+  too-many-return-statements,
+  unused-argument,
+
+[REPORTS]
+
+reports=no
+score=no
+
+[FORMAT]
+
+max-module-lines=2000

--- a/mitoc_const/trip_fees.py
+++ b/mitoc_const/trip_fees.py
@@ -1,0 +1,12 @@
+"""
+We have at least 3 places where the trip fees for various trips
+need to be kept in sync, so let's consolidate them in this
+repository.
+"""
+from collections import namedtuple
+
+TripFee = namedtuple('TripFee', ('Type', 'Amount'))
+
+ICE_TRIP = TripFee('Ice Climbing', 20)
+SKI_TRIP = TripFee('Ski', 15)
+WS_TRIP = TripFee('Winter School', 5)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='mitoc_const',
-    version='0.4.0',
+    version='0.5.0',
     author='David Cain',
     author_email='davidjosephcain@gmail.com',
     url='https://github.com/DavidCain/mitoc-const',


### PR DESCRIPTION
Added a quick namedtuple set of trip fees, and while I was add it copied over your .pylintrc (let me know if you want that in two separate PRs - happy to do that too).

Feel free to demand a test on this - the obvious one would be checking to make sure the amount is an `int`.

Question:

* Do you think we need a 2-letter code for these fees to? I just went with display name and amount, but it might be possible that we want to store this in a  later database, which suggests a 2-letter code might be the way to go, just like affiliations.